### PR TITLE
Traceability via per-Manager instance_id + UnknownEvent serialization fix + examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Corrigida a serialização de `AmiEvent::UnknownEvent` para o formato AMI correto, preservando o campo `Event` e todos os campos adicionais via flatten. Garante roundtrip JSON estável. Caso seu código dependesse do formato anterior (incorreto), ajuste sua desserialização.
+-   Fixed serialization of `AmiEvent::UnknownEvent` to the proper AMI shape, preserving the `Event` field and flattening all additional fields. Ensures stable JSON roundtrip. If your code relied on the previous (incorrect) representation, adjust your deserialization.
 
 ### Added
 
--   Rastreabilidade: `instance_id` por `Manager` com logs padronizados em criação, heartbeat e watchdog.
--   Exemplos:
-    -   `examples/watchdog_resilient_logging.rs`: watchdog mínimo com logs.
-    -   `examples/multiple_managers_logging.rs`: múltiplos Managers com `instance_id` nos logs.
-    -   `examples/roundtrip_demo.rs`: demonstra o roundtrip corrigido de `UnknownEvent`.
-    -   `examples/INSTANCE_ID.md`: documentação de `instance_id`.
+-   Traceability: per-`Manager` `instance_id` with standardized logs on creation, heartbeat, and watchdog.
+-   Examples:
+    -   `examples/watchdog_resilient_logging.rs`: minimal watchdog with logs.
+    -   `examples/multiple_managers_logging.rs`: multiple Managers with `instance_id` in logs.
+    -   `examples/roundtrip_demo.rs`: demonstrates corrected `UnknownEvent` roundtrip.
+    -   `examples/INSTANCE_ID.md`: `instance_id` documentation.
 
 ### Changed
 
--   Padronização de logs usando interpolação `{}` e melhorias de mensagens.
--   `serialize_ami_action` com interpolação formatada.
+-   Standardized log messages using `{}` interpolation; improved message consistency.
+-   Improved `serialize_ami_action` string interpolation.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2025-11-18
+
+### Fixed
+
+-   Corrigida a serialização de `AmiEvent::UnknownEvent` para o formato AMI correto, preservando o campo `Event` e todos os campos adicionais via flatten. Garante roundtrip JSON estável. Caso seu código dependesse do formato anterior (incorreto), ajuste sua desserialização.
+
+### Added
+
+-   Rastreabilidade: `instance_id` por `Manager` com logs padronizados em criação, heartbeat e watchdog.
+-   Exemplos:
+    -   `examples/watchdog_resilient_logging.rs`: watchdog mínimo com logs.
+    -   `examples/multiple_managers_logging.rs`: múltiplos Managers com `instance_id` nos logs.
+    -   `examples/roundtrip_demo.rs`: demonstra o roundtrip corrigido de `UnknownEvent`.
+    -   `examples/INSTANCE_ID.md`: documentação de `instance_id`.
+
+### Changed
+
+-   Padronização de logs usando interpolação `{}` e melhorias de mensagens.
+-   `serialize_ami_action` com interpolação formatada.
+
+---
+
 ## [2.1.0] - 2025-09-06
 
 This release introduces a comprehensive resilient connection module for production-ready, high-availability applications. The new resilient module provides automatic reconnection, heartbeat monitoring, and fault-tolerant event streaming while maintaining full backward compatibility with existing APIs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asterisk-manager"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 authors = ["Gabriel Nascimento <gabrielramosnascimento195@gmail.com>"]
 description = "An asynchronous Rust library for interacting with the Asterisk Manager Interface (AMI), featuring a strongly-typed, stream-based API with resilient connections, automatic reconnection, and heartbeat monitoring."

--- a/examples/INSTANCE_ID.md
+++ b/examples/INSTANCE_ID.md
@@ -1,47 +1,47 @@
-# Instance ID para Logging
+# Instance ID for Logging
 
-## O que é
+## What It Is
 
-Cada instância de `Manager` agora possui um **instance_id** único (primeiros 8 caracteres de um UUID v4), automaticamente gerado quando o Manager é criado. Este ID aparece em todos os logs relacionados àquela instância específica.
+Each `Manager` instance now has a unique **instance_id** (first 8 characters of a UUID v4), automatically generated at creation time. This ID appears in all logs associated with that specific instance.
 
-## Por que usar
+## Why It Matters
 
-Quando você tem múltiplas conexões AMI simultâneas (por exemplo, conectando a diferentes servidores Asterisk ou mantendo múltiplas conexões ao mesmo servidor), o instance_id permite distinguir claramente qual Manager está gerando cada log.
+When you maintain multiple simultaneous AMI connections (e.g. different Asterisk servers or several connections to the same server), the `instance_id` lets you immediately distinguish which `Manager` produced a log line.
 
-## Onde aparece nos logs
+## Where It Appears in Logs
 
-O instance_id aparece em logs de:
+The `instance_id` is included in logs for:
 
-### Manager básico
-- Criação: `Creating new Manager instance [abc12345]`
+### Core Manager
+- Creation: `Creating new Manager instance [abc12345]`
 
 ### Heartbeat
-- Início: `[abc12345] Starting heartbeat task (interval=30s)`
-- Tick: `[abc12345] Heartbeat ping successful`
-- Falha: `[abc12345] Heartbeat ping failed: <erro>`
-- Cancelamento: `[abc12345] Heartbeat task cancelled`
+- Start: `[abc12345] Starting heartbeat task (interval=30s)`
+- Success tick: `[abc12345] Heartbeat ping successful`
+- Failure: `[abc12345] Heartbeat ping failed: <error>`
+- Cancellation: `[abc12345] Heartbeat task cancelled`
 
 ### Watchdog
-- Início: `[abc12345] Starting watchdog (default interval=1s) for user 'admin' at 127.0.0.1:5038`
-- Tentativa: `[abc12345] Watchdog attempting reconnection to 'admin'@127.0.0.1:5038...`
-- Sucesso: `[abc12345] Watchdog reconnection successful to 'admin'@127.0.0.1:5038`
-- Falha: `[abc12345] Watchdog reconnection to 'admin'@127.0.0.1:5038 failed: <erro>`
-- Cancelamento: `[abc12345] Watchdog task cancelled by token`
+- Start: `[abc12345] Starting watchdog (default interval=1s) for user 'admin' at 127.0.0.1:5038`
+- Attempt: `[abc12345] Watchdog attempting reconnection to 'admin'@127.0.0.1:5038...`
+- Success: `[abc12345] Watchdog reconnection successful to 'admin'@127.0.0.1:5038`
+- Failure: `[abc12345] Watchdog reconnection to 'admin'@127.0.0.1:5038 failed: <error>`
+- Cancellation: `[abc12345] Watchdog task cancelled by token`
 
-### Resilient module
-- Conexão: `[abc12345] Connecting resilient AMI manager to 'admin'@127.0.0.1:5038`
-- Stream: `Creating new resilient stream instance [def67890]` (streams têm seus próprios IDs)
+### Resilient Module
+- Connection: `[abc12345] Connecting resilient AMI manager to 'admin'@127.0.0.1:5038`
+- Stream creation: `Creating new resilient stream instance [def67890]` (streams have their own IDs)
 
-## Exemplos práticos
+## Practical Examples
 
-### Logs de uma única conexão
+### Single Connection Logs
 ```
 [2025-10-20 ... DEBUG asterisk_manager] Creating new Manager instance [a1b2c3d4]
 [2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Starting heartbeat task (interval=30s)
 [2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Heartbeat ping successful
 ```
 
-### Logs de múltiplas conexões simultâneas
+### Multiple Concurrent Connections
 ```
 [2025-10-20 ... DEBUG asterisk_manager] Creating new Manager instance [a1b2c3d4]
 [2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Connecting resilient AMI manager to 'admin'@127.0.0.1:5038
@@ -52,32 +52,32 @@ O instance_id aparece em logs de:
 [2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Watchdog tick: already authenticated; no action taken
 ```
 
-Neste exemplo, você pode ver claramente que:
-- `[a1b2c3d4]` é a primeira conexão (porta 5038)
-- `[e5f6g7h8]` é a segunda conexão (porta 5039)
+In this example you can clearly see:
+- `[a1b2c3d4]` is the first connection (port 5038)
+- `[e5f6g7h8]` is the second connection (port 5039)
 
-## Como usar nos seus logs
+## When to Use It in Your Own Logs
 
-O instance_id é especialmente útil quando:
+The `instance_id` is especially useful for:
 
-1. **Depurando múltiplas conexões**: Rapidamente identifique qual conexão está com problema
-2. **Monitoramento**: Acompanhe métricas específicas por conexão
-3. **Troubleshooting**: Rastreie o ciclo de vida completo de uma conexão específica
-4. **Auditing**: Correlacione eventos através do tempo para uma única instância
+1. **Debugging multiple connections**: Quickly isolate which connection is misbehaving
+2. **Monitoring**: Track per-connection metrics or performance
+3. **Troubleshooting**: Follow the full lifecycle of a specific connection
+4. **Auditing**: Correlate events over time for one logical instance
 
-## Exemplos incluídos
+## Included Examples
 
-- `watchdog_resilient_logging.rs`: Mostra instance_id em uma única conexão
-- `multiple_managers_logging.rs`: Demonstra instance_id com múltiplas conexões simultâneas
+- `watchdog_resilient_logging.rs`: Shows `instance_id` in a single connection scenario
+- `multiple_managers_logging.rs`: Demonstrates `instance_id` across multiple concurrent connections
 
-## Habilitando logs detalhados
+## Enabling Detailed Logs
 
-Para ver todos os logs com instance_id:
+To view all logs with `instance_id`:
 
 ```bash
-# Logs debug de todas as operações
+# Debug-level logs for all operations
 RUST_LOG=asterisk_manager=debug cargo run --example multiple_managers_logging
 
-# Logs trace incluindo ticks do watchdog/heartbeat
+# Trace-level logs including heartbeat/watchdog ticks
 RUST_LOG=asterisk_manager=trace cargo run --example multiple_managers_logging
 ```

--- a/examples/INSTANCE_ID.md
+++ b/examples/INSTANCE_ID.md
@@ -1,0 +1,83 @@
+# Instance ID para Logging
+
+## O que é
+
+Cada instância de `Manager` agora possui um **instance_id** único (primeiros 8 caracteres de um UUID v4), automaticamente gerado quando o Manager é criado. Este ID aparece em todos os logs relacionados àquela instância específica.
+
+## Por que usar
+
+Quando você tem múltiplas conexões AMI simultâneas (por exemplo, conectando a diferentes servidores Asterisk ou mantendo múltiplas conexões ao mesmo servidor), o instance_id permite distinguir claramente qual Manager está gerando cada log.
+
+## Onde aparece nos logs
+
+O instance_id aparece em logs de:
+
+### Manager básico
+- Criação: `Creating new Manager instance [abc12345]`
+
+### Heartbeat
+- Início: `[abc12345] Starting heartbeat task (interval=30s)`
+- Tick: `[abc12345] Heartbeat ping successful`
+- Falha: `[abc12345] Heartbeat ping failed: <erro>`
+- Cancelamento: `[abc12345] Heartbeat task cancelled`
+
+### Watchdog
+- Início: `[abc12345] Starting watchdog (default interval=1s) for user 'admin' at 127.0.0.1:5038`
+- Tentativa: `[abc12345] Watchdog attempting reconnection to 'admin'@127.0.0.1:5038...`
+- Sucesso: `[abc12345] Watchdog reconnection successful to 'admin'@127.0.0.1:5038`
+- Falha: `[abc12345] Watchdog reconnection to 'admin'@127.0.0.1:5038 failed: <erro>`
+- Cancelamento: `[abc12345] Watchdog task cancelled by token`
+
+### Resilient module
+- Conexão: `[abc12345] Connecting resilient AMI manager to 'admin'@127.0.0.1:5038`
+- Stream: `Creating new resilient stream instance [def67890]` (streams têm seus próprios IDs)
+
+## Exemplos práticos
+
+### Logs de uma única conexão
+```
+[2025-10-20 ... DEBUG asterisk_manager] Creating new Manager instance [a1b2c3d4]
+[2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Starting heartbeat task (interval=30s)
+[2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Heartbeat ping successful
+```
+
+### Logs de múltiplas conexões simultâneas
+```
+[2025-10-20 ... DEBUG asterisk_manager] Creating new Manager instance [a1b2c3d4]
+[2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Connecting resilient AMI manager to 'admin'@127.0.0.1:5038
+[2025-10-20 ... DEBUG asterisk_manager] Creating new Manager instance [e5f6g7h8]
+[2025-10-20 ... DEBUG asterisk_manager] [e5f6g7h8] Connecting resilient AMI manager to 'admin2'@127.0.0.1:5039
+[2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Heartbeat ping successful
+[2025-10-20 ... DEBUG asterisk_manager] [e5f6g7h8] Watchdog attempting reconnection to 'admin2'@127.0.0.1:5039...
+[2025-10-20 ... DEBUG asterisk_manager] [a1b2c3d4] Watchdog tick: already authenticated; no action taken
+```
+
+Neste exemplo, você pode ver claramente que:
+- `[a1b2c3d4]` é a primeira conexão (porta 5038)
+- `[e5f6g7h8]` é a segunda conexão (porta 5039)
+
+## Como usar nos seus logs
+
+O instance_id é especialmente útil quando:
+
+1. **Depurando múltiplas conexões**: Rapidamente identifique qual conexão está com problema
+2. **Monitoramento**: Acompanhe métricas específicas por conexão
+3. **Troubleshooting**: Rastreie o ciclo de vida completo de uma conexão específica
+4. **Auditing**: Correlacione eventos através do tempo para uma única instância
+
+## Exemplos incluídos
+
+- `watchdog_resilient_logging.rs`: Mostra instance_id em uma única conexão
+- `multiple_managers_logging.rs`: Demonstra instance_id com múltiplas conexões simultâneas
+
+## Habilitando logs detalhados
+
+Para ver todos os logs com instance_id:
+
+```bash
+# Logs debug de todas as operações
+RUST_LOG=asterisk_manager=debug cargo run --example multiple_managers_logging
+
+# Logs trace incluindo ticks do watchdog/heartbeat
+RUST_LOG=asterisk_manager=trace cargo run --example multiple_managers_logging
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Actix Web Examples
 
-This directory contains two Actix Web examples demonstrating different approaches to using the Asterisk Manager Interface (AMI) with this crate:
+This directory contains examples demonstrating different approaches to using the Asterisk Manager Interface (AMI) with this crate:
 
 ## `watchdog_resilient_logging.rs` - Minimal Watchdog Demo
 
@@ -9,11 +9,27 @@ A minimal example that focuses on the built-in watchdog reconnection loop and it
 - Starts a `Manager` and enables only the watchdog (no web server)
 - Periodically logs authentication status
 - Shows watchdog logs like attempts, successes, and failures
+- Each Manager instance has a unique `[instance_id]` in logs
 
 Quick start:
 
 ```bash
 RUST_LOG=info,asterisk_manager=debug cargo run --example watchdog_resilient_logging
+```
+
+## `multiple_managers_logging.rs` - Multiple Connections Demo
+
+Demonstrates running multiple Manager instances simultaneously with distinct logging.
+
+- Creates two separate AMI connections with different configurations
+- Each manager has a unique `[instance_id]` visible in all logs
+- Shows how to distinguish between multiple connections in logs
+- Useful for applications that connect to multiple Asterisk servers
+
+Quick start:
+
+```bash
+RUST_LOG=info,asterisk_manager=debug cargo run --example multiple_managers_logging
 ```
 
 ## `actix_web_example.rs` - Traditional Approach

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,20 @@
 
 This directory contains two Actix Web examples demonstrating different approaches to using the Asterisk Manager Interface (AMI) with this crate:
 
+## `watchdog_resilient_logging.rs` - Minimal Watchdog Demo
+
+A minimal example that focuses on the built-in watchdog reconnection loop and its logs.
+
+- Starts a `Manager` and enables only the watchdog (no web server)
+- Periodically logs authentication status
+- Shows watchdog logs like attempts, successes, and failures
+
+Quick start:
+
+```bash
+RUST_LOG=info,asterisk_manager=debug cargo run --example watchdog_resilient_logging
+```
+
 ## `actix_web_example.rs` - Traditional Approach
 
 The original example showing manual connection management with:
@@ -82,5 +96,8 @@ let resilient_options = ResilientOptions {
 
 - **Traditional (`actix_web_example.rs`)**: When you need full control over connection management or are integrating with existing manual retry systems
 - **Resilient (`actix_web_resilient_example.rs`)**: For production applications requiring automatic recovery, minimal maintenance, and 24/7 reliability
+
+For a quick look at the watchdog behavior and logs without running a web server, use
+`watchdog_resilient_logging.rs`.
 
 The resilient approach is recommended for most production use cases as it significantly reduces code complexity while providing more robust connection handling.

--- a/examples/actix_web_example.rs
+++ b/examples/actix_web_example.rs
@@ -228,6 +228,12 @@ async fn get_calls(data: web::Data<AppState>) -> impl Responder {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv::dotenv().ok();
+    // Optional AMI connection environment variables (.env or exported):
+    //   AMI_HOST=localhost
+    //   AMI_PORT=5038
+    //   AMI_USERNAME=admin
+    //   AMI_PASSWORD=password
+    // Defaults below are applied when variables are missing.
 
     Builder::from_env(Env::new().default_filter_or("info"))
         .format(|buf, record| {

--- a/examples/actix_web_resilient_example.rs
+++ b/examples/actix_web_resilient_example.rs
@@ -269,6 +269,13 @@ async fn health_check(data: web::Data<AppState>) -> impl Responder {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv::dotenv().ok();
+    // Optional AMI/resilient connection environment variables (.env or exported):
+    //   AMI_HOST=localhost
+    //   AMI_PORT=5038
+    //   AMI_USERNAME=admin
+    //   AMI_PASSWORD=password
+    //   AMI_HEARTBEAT_INTERVAL=30    # seconds
+    // Provide overrides for production; defaults below are used otherwise.
 
     Builder::from_env(Env::new().default_filter_or("info"))
         .format(|buf, record| {

--- a/examples/actix_web_resilient_example.rs
+++ b/examples/actix_web_resilient_example.rs
@@ -134,13 +134,13 @@ async fn get_calls(data: web::Data<AppState>) -> impl Responder {
                 info!("[HTTP] GET /calls - CoreShowChannels action sent successfully.");
             }
             Ok(resp) => {
-                let err_msg = format!("CoreShowChannels action failed with response: {:?}", resp);
-                error!("[HTTP] GET /calls - {}", err_msg);
+                let err_msg = format!("CoreShowChannels action failed with response: {resp:?}");
+                error!("[HTTP] GET /calls - {err_msg}");
                 return HttpResponse::InternalServerError().body(err_msg);
             }
             Err(e) => {
-                let err_msg = format!("Error sending CoreShowChannels action: {}", e);
-                error!("[HTTP] GET /calls - {}", err_msg);
+                let err_msg = format!("Error sending CoreShowChannels action: {e}");
+                error!("[HTTP] GET /calls - {err_msg}");
                 return HttpResponse::InternalServerError().body(err_msg);
             }
         }
@@ -319,7 +319,7 @@ async fn main() -> std::io::Result<()> {
             manager
         }
         Err(e) => {
-            error!("Failed to connect to AMI: {}. The application will continue and the resilient connection will keep trying to reconnect.", e);
+            error!("Failed to connect to AMI: {e}. The application will continue and the resilient connection will keep trying to reconnect.");
             // Even if initial connection fails, the resilient system will keep trying
             match connect_resilient(resilient_options.clone()).await {
                 Ok(manager) => manager,
@@ -357,7 +357,7 @@ async fn main() -> std::io::Result<()> {
         let event_stream = match infinite_events_stream(resilient_options_for_task).await {
             Ok(stream) => stream,
             Err(e) => {
-                error!("[EVENT_TASK] Failed to create infinite event stream: {}", e);
+                error!("[EVENT_TASK] Failed to create infinite event stream: {e}");
                 return;
             }
         };
@@ -402,7 +402,7 @@ async fn main() -> std::io::Result<()> {
                         }
                     }
 
-                    info!("[AMI_EVENT] Received: {:?}", event);
+                    info!("[AMI_EVENT] Received: {event:?}");
                     let mut evs = app_state_for_task.events.lock().await;
                     evs.push(event);
 
@@ -410,8 +410,7 @@ async fn main() -> std::io::Result<()> {
                     if len > MAX_EVENT_BUFFER_SIZE {
                         let amount_to_drain = len - MAX_EVENT_BUFFER_SIZE;
                         info!(
-                            "[EVENT_TASK] Event limit reached, discarding {} old events.",
-                            amount_to_drain
+                            "[EVENT_TASK] Event limit reached, discarding {amount_to_drain} old events."
                         );
                         evs.drain(0..amount_to_drain);
                     }
@@ -426,8 +425,7 @@ async fn main() -> std::io::Result<()> {
                             _last_reconnection_duration_ms,
                         ) = app_state_for_task.metrics.snapshot();
                         info!(
-                            "[EVENT_TASK] Periodic status - Reconnections: {}, Lost: {}, Buffer: {}/{}",
-                            successful_reconnections, connection_lost_events, len, MAX_EVENT_BUFFER_SIZE
+                            "[EVENT_TASK] Periodic status - Reconnections: {successful_reconnections}, Lost: {connection_lost_events}, Buffer: {len}/{MAX_EVENT_BUFFER_SIZE}"
                         );
                         last_connection_check = Instant::now();
                     }
@@ -435,8 +433,7 @@ async fn main() -> std::io::Result<()> {
                 Err(e) => {
                     // The resilient stream handles reconnection, so errors here are just logged
                     error!(
-                        "[EVENT_TASK] Error in event stream (will auto-recover): {:?}",
-                        e
+                        "[EVENT_TASK] Error in event stream (will auto-recover): {e:?}"
                     );
                 }
             }

--- a/examples/multiple_managers_logging.rs
+++ b/examples/multiple_managers_logging.rs
@@ -1,0 +1,149 @@
+use asterisk_manager::resilient::{connect_resilient, ResilientOptions};
+use asterisk_manager::ManagerOptions;
+use chrono::Local;
+use env_logger::{Builder, Env};
+use log::info;
+use std::io::Write;
+
+// Example demonstrating multiple Manager instances with watchdog and heartbeat.
+// Each Manager has a unique instance_id visible in logs, making it easy to
+// distinguish between different connections when running multiple managers.
+//
+// Run with:
+//   RUST_LOG=info,asterisk_manager=debug \
+//   cargo run --example multiple_managers_logging
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv::dotenv().ok();
+
+    // Configure logger
+    Builder::from_env(Env::new().default_filter_or("info"))
+        .format(|buf, record| {
+            let ts = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+            writeln!(
+                buf,
+                "[{} {} {}] {}",
+                ts,
+                record.level(),
+                record.target(),
+                record.args()
+            )
+        })
+        .init();
+
+    info!("=== Starting Multiple Manager Instances Example ===");
+    info!("Each manager will have a unique [instance_id] in logs");
+    info!("");
+
+    // Configuration for first manager
+    let options1 = ResilientOptions {
+        manager_options: ManagerOptions {
+            port: std::env::var("AMI_PORT_1")
+                .unwrap_or_else(|_| "5038".to_string())
+                .parse()
+                .unwrap_or(5038),
+            host: std::env::var("AMI_HOST_1").unwrap_or_else(|_| "127.0.0.1".to_string()),
+            username: std::env::var("AMI_USERNAME_1").unwrap_or_else(|_| "admin".to_string()),
+            password: std::env::var("AMI_PASSWORD_1").unwrap_or_else(|_| "password".to_string()),
+            events: true,
+        },
+        buffer_size: 2048,
+        enable_heartbeat: true,
+        enable_watchdog: true,
+        heartbeat_interval: 10, // Short interval for demo
+        watchdog_interval: 2,   // Short interval for demo
+        max_retries: 3,
+        metrics: None,
+        cumulative_attempts_counter: None,
+    };
+
+    // Configuration for second manager (could be a different server)
+    let options2 = ResilientOptions {
+        manager_options: ManagerOptions {
+            port: std::env::var("AMI_PORT_2")
+                .unwrap_or_else(|_| "5039".to_string())
+                .parse()
+                .unwrap_or(5039),
+            host: std::env::var("AMI_HOST_2").unwrap_or_else(|_| "127.0.0.1".to_string()),
+            username: std::env::var("AMI_USERNAME_2").unwrap_or_else(|_| "admin2".to_string()),
+            password: std::env::var("AMI_PASSWORD_2")
+                .unwrap_or_else(|_| "password2".to_string()),
+            events: true,
+        },
+        buffer_size: 2048,
+        enable_heartbeat: true,
+        enable_watchdog: true,
+        heartbeat_interval: 15, // Different interval
+        watchdog_interval: 3,   // Different interval
+        max_retries: 5,
+        metrics: None,
+        cumulative_attempts_counter: None,
+    };
+
+    info!("Creating first manager connection...");
+    let manager1 = match connect_resilient(options1).await {
+        Ok(m) => {
+            info!("✓ First manager connected successfully");
+            Some(m)
+        }
+        Err(e) => {
+            info!("✗ First manager failed to connect: {e}");
+            info!("  (watchdog will keep trying to reconnect)");
+            None
+        }
+    };
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    info!("");
+    info!("Creating second manager connection...");
+    let manager2 = match connect_resilient(options2).await {
+        Ok(m) => {
+            info!("✓ Second manager connected successfully");
+            Some(m)
+        }
+        Err(e) => {
+            info!("✗ Second manager failed to connect: {e}");
+            info!("  (watchdog will keep trying to reconnect)");
+            None
+        }
+    };
+
+    info!("");
+    info!("=== Both managers are now running ===");
+    info!("Watch the logs to see [instance_id] for each manager:");
+    info!("  - Heartbeat pings every 10s (manager1) and 15s (manager2)");
+    info!("  - Watchdog checks every 2s (manager1) and 3s (manager2)");
+    info!("");
+    info!("Set RUST_LOG=asterisk_manager=debug to see detailed logs.");
+    info!("Press Ctrl+C to exit.");
+
+    // Periodic status check
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
+        loop {
+            interval.tick().await;
+            let auth1 = if let Some(ref m) = manager1 {
+                m.is_authenticated().await
+            } else {
+                false
+            };
+            let auth2 = if let Some(ref m) = manager2 {
+                m.is_authenticated().await
+            } else {
+                false
+            };
+            info!(
+                "Status check - Manager1: {}, Manager2: {}",
+                if auth1 { "✓ authenticated" } else { "✗ not authenticated" },
+                if auth2 { "✓ authenticated" } else { "✗ not authenticated" }
+            );
+        }
+    });
+
+    // Keep the process alive
+    tokio::signal::ctrl_c().await?;
+    info!("Shutting down example.");
+    Ok(())
+}

--- a/examples/multiple_managers_logging.rs
+++ b/examples/multiple_managers_logging.rs
@@ -16,6 +16,17 @@ use std::io::Write;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
+    // Optional environment variables (.env) to override defaults used below.
+    // Create a .env file with e.g.:
+    //   AMI_HOST_1=127.0.0.1
+    //   AMI_PORT_1=5038
+    //   AMI_USERNAME_1=admin
+    //   AMI_PASSWORD_1=password
+    //   AMI_HOST_2=127.0.0.1
+    //   AMI_PORT_2=5039
+    //   AMI_USERNAME_2=admin2
+    //   AMI_PASSWORD_2=password2
+    // If not set, the fallback values in the ResilientOptions below are used.
 
     // Configure logger
     Builder::from_env(Env::new().default_filter_or("info"))

--- a/examples/roundtrip_demo.rs
+++ b/examples/roundtrip_demo.rs
@@ -1,0 +1,63 @@
+//! Demonstration that the serialization/deserialization bug is fixed
+//!
+//! This example demonstrates that AmiEvent::UnknownEvent can now be:
+//! 1. Serialized to JSON
+//! 2. Sent through a message queue (simulated)
+//! 3. Deserialized back without data loss
+//!
+//! This was previously broken - the event_type would become "UnknownOrMalformed"
+
+use asterisk_manager::AmiEvent;
+use std::collections::HashMap;
+
+fn main() {
+    println!("=== AmiEvent::UnknownEvent Serialization Round-Trip Test ===\n");
+
+    // 1. Create an UnknownEvent (as the library does when receiving from Asterisk)
+    let mut fields = HashMap::new();
+    fields.insert("Event".to_string(), "ContactStatus".to_string());
+    fields.insert("AOR".to_string(), "1000021005".to_string());
+    fields.insert("ContactStatus".to_string(), "Removed".to_string());
+    fields.insert("URI".to_string(), "sip:1000021005@10.0.0.1:5060".to_string());
+
+    let original = AmiEvent::UnknownEvent {
+        event_type: "ContactStatus".to_string(),
+        fields: fields.clone(),
+    };
+
+    println!("1. Original event:");
+    println!("   {:?}\n", original);
+
+    // 2. Serialize to JSON (e.g., to send via Kafka, RabbitMQ, etc.)
+    let json = serde_json::to_string(&original).unwrap();
+    println!("2. Serialized to JSON:");
+    println!("   {}\n", json);
+
+    // 3. Deserialize back (e.g., consumer receives from message queue)
+    let deserialized: AmiEvent = serde_json::from_str(&json).unwrap();
+    println!("3. Deserialized event:");
+    println!("   {:?}\n", deserialized);
+
+    // 4. Verify the data is preserved
+    match deserialized {
+        AmiEvent::UnknownEvent { event_type, fields } => {
+            println!("✅ SUCCESS: Event round-trip completed successfully!");
+            println!("   - Event type: {} (preserved)", event_type);
+            println!("   - AOR: {:?} (preserved)", fields.get("AOR"));
+            println!("   - ContactStatus: {:?} (preserved)", fields.get("ContactStatus"));
+            println!("   - URI: {:?} (preserved)", fields.get("URI"));
+            println!("\n✅ All fields preserved correctly!");
+            
+            // Verify assertions
+            assert_eq!(event_type, "ContactStatus");
+            assert_eq!(fields.get("AOR"), Some(&"1000021005".to_string()));
+            assert_eq!(fields.get("ContactStatus"), Some(&"Removed".to_string()));
+        }
+        other => {
+            println!("❌ FAILURE: Got unexpected event type: {:?}", other);
+            panic!("Round-trip failed!");
+        }
+    }
+
+    println!("\n=== Test Complete ===");
+}

--- a/examples/watchdog_resilient_logging.rs
+++ b/examples/watchdog_resilient_logging.rs
@@ -1,0 +1,87 @@
+use asterisk_manager::{Manager, ManagerOptions};
+use chrono::Local;
+use env_logger::{Builder, Env};
+use log::{info, warn};
+use std::io::Write;
+
+// A minimal example to demonstrate the built-in watchdog reconnection task
+// and how to see its logs. The watchdog runs periodically and, when the
+// manager is not authenticated, it attempts to connect_and_login using the
+// provided ManagerOptions. Its internal logs include:
+//   - "Watchdog attempting reconnection..." (debug)
+//   - "Watchdog reconnection successful" (info)
+//   - "Watchdog reconnection failed: <error>" (debug)
+// To see these messages, run with RUST_LOG including `asterisk_manager=debug`.
+//
+// Example run:
+//   RUST_LOG=info,asterisk_manager=debug \
+//   cargo run --example watchdog_resilient_logging
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv::dotenv().ok();
+
+    // Configure logger: default to "info" but allow overriding via RUST_LOG
+    Builder::from_env(Env::new().default_filter_or("info"))
+        .format(|buf, record| {
+            let ts = Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+            writeln!(
+                buf,
+                "[{} {} {}] {}",
+                ts,
+                record.level(),
+                record.target(),
+                record.args()
+            )
+        })
+        .init();
+
+    // Read AMI connection info from env vars or use defaults
+    let options = ManagerOptions {
+        port: std::env::var("AMI_PORT")
+            .unwrap_or_else(|_| "5038".to_string())
+            .parse()
+            .unwrap_or(5038),
+        host: std::env::var("AMI_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
+        username: std::env::var("AMI_USERNAME").unwrap_or_else(|_| "admin".to_string()),
+        password: std::env::var("AMI_PASSWORD").unwrap_or_else(|_| "password".to_string()),
+        events: true,
+    };
+
+    // Start with a fresh manager (not authenticated yet)
+    let manager = Manager::new();
+
+    // Start only the watchdog with a short interval (in seconds).
+    // The watchdog will try to connect until success and will log attempts.
+    manager
+        .start_watchdog_with_interval(options.clone(), 2)
+        .await?;
+
+    info!(
+        "Watchdog started (interval=2s). Set RUST_LOG=asterisk_manager=debug to see detailed attempts."
+    );
+    info!(
+        "Environment: AMI_HOST={}, AMI_PORT={}",
+        options.host, options.port
+    );
+
+    // Optional: observe authentication status every 5 seconds
+    let manager_clone = manager.clone();
+    tokio::spawn(async move {
+        loop {
+            let auth = manager_clone.is_authenticated().await;
+            if auth {
+                info!("Status: authenticated to AMI");
+            } else {
+                warn!("Status: not authenticated (watchdog will attempt reconnect)");
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        }
+    });
+
+    // Keep the process alive so we can observe the watchdog behavior.
+    // Ctrl+C to exit.
+    tokio::signal::ctrl_c().await?;
+    info!("Shutting down example.");
+    Ok(())
+}

--- a/examples/watchdog_resilient_logging.rs
+++ b/examples/watchdog_resilient_logging.rs
@@ -20,6 +20,12 @@ use std::io::Write;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
+    // Optional AMI connection environment variables (load from .env or exported):
+    //   AMI_HOST=127.0.0.1
+    //   AMI_PORT=5038
+    //   AMI_USERNAME=admin
+    //   AMI_PASSWORD=password
+    // Defaults below are used if variables are absent.
 
     // Configure logger: default to "info" but allow overriding via RUST_LOG
     Builder::from_env(Env::new().default_filter_or("info"))


### PR DESCRIPTION
- Summary:
  - Fixed: Serialize `AmiEvent::UnknownEvent` to the proper AMI shape, preserving `Event` and flattening additional fields. Ensures stable JSON roundtrip. If you relied on the previous (incorrect) representation, update your deserialization.
  - Added: Per-`Manager` `instance_id` with standardized logs across creation, heartbeat, and watchdog.
  - Examples: `watchdog_resilient_logging.rs`, `multiple_managers_logging.rs`, `roundtrip_demo.rs`, and INSTANCE_ID.md.
  - Changed: Standardized log messages using `{}` interpolation and improved `serialize_ami_action` formatting.
- Details:
  - Traceability: Easier debugging when multiple Managers are active; logs now include a concise `instance_id`.
  - Resilient flows: Better visibility for heartbeat and watchdog behaviors.
  - Serialization: `UnknownEvent` now roundtrips cleanly; the representation matches AMI conventions (field `Event` + flattened rest).
- Compatibility:
  - The `UnknownEvent` shape correction is considered a bug fix. Consumers depending on the previous incorrect shape should adjust deserialization. No API changes expected.
- Testing:
  - `cargo test` passes. New examples can be run with:
    - `RUST_LOG=info,asterisk_manager=debug cargo run --example watchdog_resilient_logging`
    - `RUST_LOG=info,asterisk_manager=debug cargo run --example multiple_managers_logging`
    - `cargo run --example roundtrip_demo`
- Checklist:
  - [x] Changelog updated
  - [x] Examples added
  - [x] Tests pass
